### PR TITLE
Add event if result is empty

### DIFF
--- a/src/avanti-search.js
+++ b/src/avanti-search.js
@@ -293,6 +293,11 @@
         var $list = self.options.$result.find('> div > ul');
         var $products = $(response).find('ul');
 
+        if($products.length === 0) {
+          self.options.$result.trigger('avantisearch.emptyResult', [self.options, self.request]);
+          return;
+        }
+
         $products.find('.last, .first').removeClass('last first');
         $products.find('.helperComplement').remove();
 


### PR DESCRIPTION
Fixes #14 

Added an event if result is empty. The name of the event is `avantisearch.emptyResult`